### PR TITLE
refactor: use returnErrorStatus function where is not used

### DIFF
--- a/Backend/src/Controllers/AuthController.js
+++ b/Backend/src/Controllers/AuthController.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 
 // Local Imports:
 import userModel from '../Models/UserModel.js';
+import { returnErrorStatus } from '../Utils/errorUtils.js';
 import { validatePartialUser, validateUser } from '../Schemas/userSchema.js';
 import {
     validatePasswords,

--- a/Backend/src/Controllers/LikesController.js
+++ b/Backend/src/Controllers/LikesController.js
@@ -1,0 +1,25 @@
+// Local Imports:
+import likesModel from '../Models/LikesModel.js';
+import userModel from '../Models/UserModel.js';
+import { returnErrorStatus } from '../Utils/errorUtils.js';
+import StatusMessage from '../Utils/StatusMessage.js';
+
+export default class LikesController {
+    static async saveLike(req, res) {
+        const { userId } = req.params;
+        const likeEmitterId = req.session.user.id;
+
+        if (userId === likeEmitterId) return res.status(400).json({ msg: StatusMessage.CANNOT_LIKE_YOURSELF });
+
+        const validIds = await LikesController.validateId(res, userId);
+        if (!validIds) return res;
+    }
+
+    static async validateId(res, id) {
+        let id = userId;
+        const userIdCheck = await userModel.getById({ id });
+        if (!userIdCheck) return returnErrorStatus(res, 500, StatusMessage.QUERY_ERROR);
+        if (userIdCheck.length === 0) returnErrorStatus(res, 404, StatusMessage.USER_NOT_FOUND)
+        return true;
+    }
+}

--- a/Backend/src/Controllers/LikesController.js
+++ b/Backend/src/Controllers/LikesController.js
@@ -9,7 +9,10 @@ export default class LikesController {
         const { userId } = req.params;
         const likeEmitterId = req.session.user.id;
 
-        if (userId === likeEmitterId) return res.status(400).json({ msg: StatusMessage.CANNOT_LIKE_YOURSELF });
+        if (userId === likeEmitterId)
+            return res
+                .status(400)
+                .json({ msg: StatusMessage.CANNOT_LIKE_YOURSELF });
 
         const validIds = await LikesController.validateId(res, userId);
         if (!validIds) return res;
@@ -18,8 +21,10 @@ export default class LikesController {
     static async validateId(res, id) {
         let id = userId;
         const userIdCheck = await userModel.getById({ id });
-        if (!userIdCheck) return returnErrorStatus(res, 500, StatusMessage.QUERY_ERROR);
-        if (userIdCheck.length === 0) returnErrorStatus(res, 404, StatusMessage.USER_NOT_FOUND)
+        if (!userIdCheck)
+            return returnErrorStatus(res, 500, StatusMessage.QUERY_ERROR);
+        if (userIdCheck.length === 0)
+            returnErrorStatus(res, 404, StatusMessage.USER_NOT_FOUND);
         return true;
     }
 }

--- a/Backend/src/Controllers/UsersController.js
+++ b/Backend/src/Controllers/UsersController.js
@@ -367,7 +367,8 @@ export default class UsersController {
         };
 
         const result = await imagesModel.create({ input });
-        if (!result || result.length === 0) return returnErrorStatus(res, 500, StatusMessage.QUERY_ERROR)
+        if (!result || result.length === 0)
+            return returnErrorStatus(res, 500, StatusMessage.QUERY_ERROR);
 
         return true;
     }
@@ -411,7 +412,12 @@ export default class UsersController {
             visited_id: visitedProfileId,
         };
         const visit = await visitHistoryModel.getByReference(reference, true);
-        if (!visit) return returnErrorStatus(res, 500, StatusMessage.INTERNAL_SERVER_ERROR)
+        if (!visit)
+            return returnErrorStatus(
+                res,
+                500,
+                StatusMessage.INTERNAL_SERVER_ERROR
+            );
 
         let input = {
             visitor_id: visitorId,
@@ -422,12 +428,14 @@ export default class UsersController {
         if (visit && visit.length !== 0) {
             const { id } = visit;
             const updateResult = await visitHistoryModel.update({ input, id });
-            if (!updateResult || updateResult.length === 0) return returnErrorStatus(res, 500, StatusMessage.QUERY_ERROR)
+            if (!updateResult || updateResult.length === 0)
+                return returnErrorStatus(res, 500, StatusMessage.QUERY_ERROR);
             return true;
         }
 
         const visitUpdateResult = await visitHistoryModel.create({ input });
-        if (!visitUpdateResult || visitUpdateResult.length === 0) return returnErrorStatus(res, 500, StatusMessage.QUERY_ERROR)
+        if (!visitUpdateResult || visitUpdateResult.length === 0)
+            return returnErrorStatus(res, 500, StatusMessage.QUERY_ERROR);
 
         return true;
     }

--- a/Backend/src/Controllers/UsersController.js
+++ b/Backend/src/Controllers/UsersController.js
@@ -6,10 +6,9 @@ import fsExtra from 'fs-extra';
 import userModel from '../Models/UserModel.js';
 import userTagsModel from '../Models/UserTagsModel.js';
 import { validatePartialUser } from '../Schemas/userSchema.js';
-import { returnErrorStatus } from '../Utils/authUtils.js';
 import getPublicUser from '../Utils/getPublicUser.js';
 import StatusMessage from '../Utils/StatusMessage.js';
-import { returnErrorWithNext } from '../Utils/errorUtils.js';
+import { returnErrorWithNext, returnErrorStatus } from '../Utils/errorUtils.js';
 import imagesModel from '../Models/ImagesModel.js';
 import visitHistoryModel from '../Models/VisitHistoryModel.js';
 import { getCurrentTimestamp } from '../Utils/timeUtils.js';
@@ -368,10 +367,7 @@ export default class UsersController {
         };
 
         const result = await imagesModel.create({ input });
-        if (!result || result.length === 0) {
-            res.status(500).json({ msg: StatusMessage.QUERY_ERROR });
-            return false;
-        }
+        if (!result || result.length === 0) return returnErrorStatus(res, 500, StatusMessage.QUERY_ERROR)
 
         return true;
     }
@@ -415,10 +411,7 @@ export default class UsersController {
             visited_id: visitedProfileId,
         };
         const visit = await visitHistoryModel.getByReference(reference, true);
-        if (!visit) {
-            res.status(500).json({ msg: StatusMessage.INTERNAL_SERVER_ERROR });
-            return false;
-        }
+        if (!visit) return returnErrorStatus(res, 500, StatusMessage.INTERNAL_SERVER_ERROR)
 
         let input = {
             visitor_id: visitorId,
@@ -429,18 +422,12 @@ export default class UsersController {
         if (visit && visit.length !== 0) {
             const { id } = visit;
             const updateResult = await visitHistoryModel.update({ input, id });
-            if (!updateResult || updateResult.length === 0) {
-                res.status(500).json({ msg: StatusMessage.QUERY_ERROR });
-                return false;
-            }
+            if (!updateResult || updateResult.length === 0) return returnErrorStatus(res, 500, StatusMessage.QUERY_ERROR)
             return true;
         }
 
         const visitUpdateResult = await visitHistoryModel.create({ input });
-        if (!visitUpdateResult || visitUpdateResult.length === 0) {
-            res.status(500).json({ msg: StatusMessage.QUERY_ERROR });
-            return false;
-        }
+        if (!visitUpdateResult || visitUpdateResult.length === 0) return returnErrorStatus(res, 500, StatusMessage.QUERY_ERROR)
 
         return true;
     }

--- a/Backend/src/Utils/authUtils.js
+++ b/Backend/src/Utils/authUtils.js
@@ -86,11 +86,6 @@ export async function hashPassword(password) {
     return encryptedPassword;
 }
 
-export function returnErrorStatus(res, statusCode, errorMsg) {
-    res.status(statusCode).json({ msg: errorMsg });
-    return false;
-}
-
 export function isIgnored(ignoredRoutes, path) {
     return ignoredRoutes.some((pattern) => {
         const regex = new RegExp('^' + pattern.replace(/\*/g, '[^/]+') + '$');

--- a/Backend/src/Utils/errorUtils.js
+++ b/Backend/src/Utils/errorUtils.js
@@ -2,3 +2,8 @@ export function returnErrorWithNext(res, next, statusCode, errorMessage) {
     if (!res.responseData) res.status(statusCode).json({ msg: errorMessage });
     return next(new Error(errorMessage));
 }
+
+export function returnErrorStatus(res, statusCode, errorMsg) {
+    res.status(statusCode).json({ msg: errorMsg });
+    return false;
+}

--- a/Backend/src/Validations/authValidations.js
+++ b/Backend/src/Validations/authValidations.js
@@ -5,7 +5,7 @@ import bcrypt from 'bcryptjs';
 import userModel from '../Models/UserModel.js';
 import { validatePartialUser } from '../Schemas/userSchema.js';
 import StatusMessage from '../Utils/StatusMessage.js';
-import { returnErrorStatus } from '../Utils/authUtils.js';
+import { returnErrorStatus } from '../Utils/errorUtils.js';
 
 export async function passwordValidations(data) {
     const { res, token, id, newPassword, oldPassword } = data;


### PR DESCRIPTION
This pull request focuses on improving error handling and code organization in the backend controllers by centralizing the `returnErrorStatus` utility function. The changes include importing the `returnErrorStatus` function from a unified location, refactoring the code to use this function, and adding a new controller for handling likes.

Improvements to error handling:

* [`Backend/src/Controllers/AuthController.js`](diffhunk://#diff-6db7607c5e679cf8d18f1a4d76045799905719d077e509fa1da277240cdee889R7): Imported `returnErrorStatus` from `errorUtils.js` to centralize error handling.
* [`Backend/src/Controllers/UsersController.js`](diffhunk://#diff-56f018579659adfeaf94449113cc636c51fe4316620354c4bf5d89439d20323bL9-R11): Refactored multiple methods to use `returnErrorStatus` for consistent error handling. [[1]](diffhunk://#diff-56f018579659adfeaf94449113cc636c51fe4316620354c4bf5d89439d20323bL9-R11) [[2]](diffhunk://#diff-56f018579659adfeaf94449113cc636c51fe4316620354c4bf5d89439d20323bL371-R371) [[3]](diffhunk://#diff-56f018579659adfeaf94449113cc636c51fe4316620354c4bf5d89439d20323bL418-R420) [[4]](diffhunk://#diff-56f018579659adfeaf94449113cc636c51fe4316620354c4bf5d89439d20323bL432-R438)
* [`Backend/src/Validations/authValidations.js`](diffhunk://#diff-b4b806cb9240c34a07635158b3e69955a754e2816c54b49967842c5d338b2a37L8-R8): Changed the import of `returnErrorStatus` to `errorUtils.js` for consistency.

Code organization:

* [`Backend/src/Utils/errorUtils.js`](diffhunk://#diff-e52b2c0e16b95dc9e2f8618902b0181081009ff1f247547cbc264cd76ca7fb90R5-R9): Moved `returnErrorStatus` function from `authUtils.js` to `errorUtils.js` to centralize error handling utilities.