### PR TITLE
feat: change frontend port

### DIFF
--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: "0.0.0.0",
-    port: 3000,
+    port: 5173,
   },
 });


### PR DESCRIPTION
This pull request updates the server configuration in the `vite.config.ts` file to change the default port used for the development server.

* [`Frontend/vite.config.ts`](diffhunk://#diff-f7c5d0d2bbf1cef3060437fa2ad42d7a44f1014448f4f0b54a2326dd6d89732aL9-R9): Updated the `server.port` configuration from `3000` to `5173` to align with the default port used by Vite.