### PR TITLE
feat: cheange docker compose ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,9 @@ services:
             retries: 5
         restart: on-failure
         ports:
-            - "5432:5432"
+            - "${POSTGRESQL_PORT}:${POSTGRESQL_PORT}"
         expose:
-            - "5432"
+            - "${POSTGRESQL_PORT}"
 
     backend:
         container_name: backend
@@ -46,7 +46,7 @@ services:
                 condition: service_healthy
         env_file: .env
         ports:
-            - "3001:3001"
+            - "${API_PORT}:${API_PORT}"
         restart: on-failure
 
     frontend:
@@ -62,9 +62,9 @@ services:
             TZ: ${TIMEZONE}
         env_file: .env
         ports:
-            - "3000:3000"
+            - "${FRONTEND_PORT}:${FRONTEND_PORT}"
         expose:
-            - "3000"
+            - "${FRONTEND_PORT}"
         restart: on-failure
 
 volumes:


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file to make port configurations dynamic by replacing hardcoded port values with environment variables. This change improves flexibility and allows easier customization of port mappings across different environments.

### Dynamic port configuration updates:

* [`services.postgres`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L28-R30): Replaced hardcoded port `5432` with the `POSTGRESQL_PORT` environment variable for both `ports` and `expose` directives.
* [`services.backend`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L49-R49): Replaced hardcoded port `3001` with the `API_PORT` environment variable in the `ports` directive.
* [`services.frontend`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L65-R67): Replaced hardcoded port `3000` with the `FRONTEND_PORT` environment variable for both `ports` and `expose` directives.